### PR TITLE
Create missing local path on new nodes using S3

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -153,6 +153,7 @@ echo "  node: [${NODE_BACKUP_TIMES}]"
 
 if [[ ! -z ${S3_PATH} ]] && is_master ; then
   setnode
+  mkdir -p ${ETCD_BACKUP_DIR}
   testfile=${ETCD_BACKUP_DIR}/test-${NODE_NAME}
   echo "Testing backup of ${testfile}"
   echo "test" > ${testfile}


### PR DESCRIPTION
This was required as the tests create the backup path and don't run an S3 ETE backup (yet)

In dev the nodes had run an old version. Bug discovered in playground.