### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,23 @@
 
 [![Build Status](https://drone.digital.homeoffice.gov.uk/api/badges/UKHomeOffice/docker-etcd-backup/status.svg)](https://drone.digital.homeoffice.gov.uk/UKHomeOffice/docker-etcd-backup)
 
-Backup process for etcd2 (etcd3 is much simpler)
-
-## Design
-
-Due to the complexities of restoring a cluster two approaches are used:
-
-1. node backup (quick to restore but dependant on a quorum of restored nodes)
-2. cluster backup (complex to restore)
-
-## Node backup
-
-A node backup (tar) is performed throughout the day. Each node will push all data content to a backup location.
+Cluster Backup process for etcd3
 
 ## Cluster backup
 
-A cluster backup is taken once a day. Only one node will save the latest backup.
-
-A cluster backup is made with `etcdctl backup` which strips node information thus requiring a cluster rebuild.
+A cluster backup is made with `etcdctl backup` which strips node information thus requiring a cluster rebuild. This backup is saved as a tar file in the `/tmp` directory by default. If `S3_PATH` is specified it will be uploaded to S3 and encrypted with the KMS key that you have specified using the `KMS_ID` variable.
 
 ## Environment Variables
 
-* `CLUSTER_BACKUP_TIMES:-0000` Times to carry out node agnostic cluster backups
-* `NODE_BACKUP_TIMES:-0100 0700 1300 1900` Times to backup node data
-* `ETCD_DATA_DIR` Location to backup from (will result in NOOP if not present)
-* `ETCD_BACKUP_DIR` The root directory to backup to
-* `ENV_FILE:-/etc/environment` Will be sourced if specified
-* `NODE_NAME` Will be audited from ETCD_ENDPOINTS if not present
-* `ETCD_ENDPOINTS:-https://localhost:2379`
-* `EXIT_AT` Allows setting a time to exit (for testing)
+* `BACKUP_PATH:-/tmp` The root directory to backup to
+* `ETCD_ENDPOINT:-https://localhost:4001`
 * `S3_PATH` Will backup to this path and delete off host when done
 * `KMS_ID` Specifies which KMS encryption key to use in S3
-
-## BackUp Now Flag
-
-Create a file called `${ETCD_BACKUP_DIR}/bunf` to initiate a node and cluster backup (it will be deleted when done).
+* `CA_FILE:-/srv/kubernetes/ca.crt` Path to the CA for your etcd cluster
+* `ETCDCTL_CERT` Path to the cert for your etcd cluster
+* `ETCDCTL_KEY` Path to the private key for your etcd cert
 
 ## Restore process
-
-### From Node Backup
-
-1. Stop ETCD everywhere
-2. Restore the latest .tar.gz file from `${ETCD_BACKUP_DIR}/YY/MM/DD/*.tar.gz` to the `${ETCD_DATA_DIR}`
 
 ### From Cluster Backup
 


### PR DESCRIPTION
I found this repo very handy, not many things do etcd backups with both s3 and kms for some reason. However it appears the readme is totally at odds with what it actually does so I thought I'd update it for you. As I understand it only does Cluster backups and is now intended to be ran as Cron Job in kube as opposed to using crontab stuff.